### PR TITLE
Update .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-@sfccdevops:registry=https://npm.pkg.github.com
+@opensfcc:registry=https://npm.pkg.github.com
 audit=false
 fund=false
 loglevel=error


### PR DESCRIPTION
Moving SFCC DevOps projects to OpenSFCC as part of a much larger Open Source Community Effort.

